### PR TITLE
Added libboost-serialization-dev to debian and ubuntu docker files. 

### DIFF
--- a/debian-testing/Dockerfile
+++ b/debian-testing/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
     clang-format-${LLVM_VERSION} \
     pkg-config \
     libboost-filesystem-dev \
-    libboost-regex-dev \
+    libboost-serialization-dev \
     libgtksourceviewmm-3.0-dev \
     aspell-en \
     libaspell-dev \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     clang-format-${LLVM_VERSION} \
     pkg-config \
     libboost-filesystem-dev \
-    libboost-regex-dev \
+    libboost-serialization-dev \
     libgtksourceviewmm-3.0-dev \
     aspell-en \
     libaspell-dev \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     clang-format-${LLVM_VERSION} \
     pkg-config \
     libboost-filesystem-dev \
-    libboost-regex-dev \
+    libboost-serialization-dev \
     libgtksourceviewmm-3.0-dev \
     aspell-en \
     libaspell-dev \


### PR DESCRIPTION
@zalox Boost.Serialization is needed for caching usages that I'm currently working on (see my jucipp fork). 